### PR TITLE
Added foreign keys to models with relations

### DIFF
--- a/bin/migrate
+++ b/bin/migrate
@@ -1,2 +1,3 @@
 #!/bin/bash
 go run migrations/*.go "$@"
+ATOMIC_INSIGHT_ENV=test go run migrations/*.go "$@"

--- a/migrations/20210412211919_create_lti_schema.go
+++ b/migrations/20210412211919_create_lti_schema.go
@@ -19,6 +19,9 @@ type LtiDeployment struct {
 	ID           int64
 	DeploymentID string `pg:",notnull"`
 
+	LtiInstallID          int64
+	ApplicationInstanceID int64
+
 	Timestamps
 }
 
@@ -29,6 +32,8 @@ type User struct {
 	LmsUserId   string `pg:",notnull"`
 	LtiUserId   string `pg:",notnull"`
 	LtiProvider string `pg:",notnull"`
+
+	ApplicationInstanceID int64
 
 	Timestamps
 }
@@ -57,6 +62,8 @@ type ApplicationInstance struct {
 	LtiLaunches           []*LtiLaunch       `pg:"rel:has-many"`
 	Users                 []*User            `pg:"rel:has-many"`
 
+	ApplicationID int64
+
 	Timestamps
 }
 
@@ -65,12 +72,16 @@ type Jwk struct {
 	kid string `pg:",notnull"`
 	pem string `pg:",notnull"`
 
+	ApplicationID int64
+
 	Timestamps
 }
 
 type LtiInstall struct {
 	ID             int64
 	LtiDeployments []*LtiDeployment `pg:"rel:has-many"`
+
+	ApplicationID int64
 
 	Timestamps
 }

--- a/migrations/20210412211919_create_lti_schema.go
+++ b/migrations/20210412211919_create_lti_schema.go
@@ -33,6 +33,20 @@ type User struct {
 	Timestamps
 }
 
+type LtiLaunch struct {
+	ID                       int64
+	DeploymentID             string             `pg:",notnull"`
+	Config                   *ApplicationConfig `pg:"type:jsonb,notnull"`
+	ContextID                string             `pg:",notnull"`
+	ResourceLinkID           string             `pg:",notnull"`
+	Token                    string             `pg:",notnull"`
+	ToolConsumerInstanceGuid string             `pg:",notnull"`
+
+	ApplicationInstanceID int64
+
+	Timestamps
+}
+
 type ApplicationInstance struct {
 	ID                    int64
 	ClientApplicationName string             `pg:",notnull"`
@@ -40,6 +54,7 @@ type ApplicationInstance struct {
 	Description           string             `pg:",notnull"`
 	Key                   string             `pg:",notnull"`
 	LtiDeployments        []*LtiDeployment   `pg:"rel:has-many"`
+	LtiLaunches           []*LtiLaunch       `pg:"rel:has-many"`
 	Users                 []*User            `pg:"rel:has-many"`
 
 	Timestamps
@@ -78,6 +93,7 @@ type Application struct {
 var models []interface{} = []interface{}{
 	(*LtiDeployment)(nil),
 	(*User)(nil),
+	(*LtiLaunch)(nil),
 	(*ApplicationInstance)(nil),
 	(*Jwk)(nil),
 	(*LtiInstall)(nil),

--- a/migrations/20210412211919_create_lti_schema.go
+++ b/migrations/20210412211919_create_lti_schema.go
@@ -19,8 +19,8 @@ type LtiDeployment struct {
 	ID           int64
 	DeploymentID string `pg:",notnull"`
 
-	LtiInstallID          int64
-	ApplicationInstanceID int64
+	LtiInstallID          int64 `pg:"on_delete:CASCADE"`
+	ApplicationInstanceID int64 `pg:"on_delete:CASCADE"`
 
 	Timestamps
 }
@@ -33,7 +33,7 @@ type User struct {
 	LtiUserId   string `pg:",notnull"`
 	LtiProvider string `pg:",notnull"`
 
-	ApplicationInstanceID int64
+	ApplicationInstanceID int64 `pg:"on_delete:CASCADE"`
 
 	Timestamps
 }
@@ -47,7 +47,7 @@ type LtiLaunch struct {
 	Token                    string             `pg:",notnull"`
 	ToolConsumerInstanceGuid string             `pg:",notnull"`
 
-	ApplicationInstanceID int64
+	ApplicationInstanceID int64 `pg:"on_delete:CASCADE"`
 
 	Timestamps
 }
@@ -62,7 +62,7 @@ type ApplicationInstance struct {
 	LtiLaunches           []*LtiLaunch       `pg:"rel:has-many"`
 	Users                 []*User            `pg:"rel:has-many"`
 
-	ApplicationID int64
+	ApplicationID int64 `pg:"on_delete:CASCADE"`
 
 	Timestamps
 }
@@ -72,7 +72,7 @@ type Jwk struct {
 	kid string `pg:",notnull"`
 	pem string `pg:",notnull"`
 
-	ApplicationID int64
+	ApplicationID int64 `pg:"on_delete:CASCADE"`
 
 	Timestamps
 }
@@ -81,7 +81,7 @@ type LtiInstall struct {
 	ID             int64
 	LtiDeployments []*LtiDeployment `pg:"rel:has-many"`
 
-	ApplicationID int64
+	ApplicationID int64 `pg:"on_delete:CASCADE"`
 
 	Timestamps
 }

--- a/migrations/main.go
+++ b/migrations/main.go
@@ -4,14 +4,14 @@ import (
 	"log"
 	"os"
 
-	"github.com/atomicjolt/atomic_insight/model"
+	"github.com/atomicjolt/atomic_insight/repo"
 	migrations "github.com/robinjoseph08/go-pg-migrations/v3"
 )
 
 const directory = "migrations"
 
 func main() {
-	db := model.GetConnection()
+	db := repo.GetConnection()
 
 	err := migrations.Run(db, directory, os.Args)
 	if err != nil {

--- a/model/application_instance.go
+++ b/model/application_instance.go
@@ -10,5 +10,7 @@ type ApplicationInstance struct {
 	LtiLaunches           []*LtiLaunch       `pg:"rel:has-many"`
 	Users                 []*User            `pg:"rel:has-many"`
 
+	ApplicationID int64
+
 	Timestamps
 }

--- a/model/application_instance.go
+++ b/model/application_instance.go
@@ -7,6 +7,7 @@ type ApplicationInstance struct {
 	Description           string             `pg:",notnull"`
 	Key                   string             `pg:",notnull"`
 	LtiDeployments        []*LtiDeployment   `pg:"rel:has-many"`
+	LtiLaunches           []*LtiLaunch       `pg:"rel:has-many"`
 	Users                 []*User            `pg:"rel:has-many"`
 
 	Timestamps

--- a/model/application_instance.go
+++ b/model/application_instance.go
@@ -10,7 +10,7 @@ type ApplicationInstance struct {
 	LtiLaunches           []*LtiLaunch       `pg:"rel:has-many"`
 	Users                 []*User            `pg:"rel:has-many"`
 
-	ApplicationID int64
+	ApplicationID int64 `pg:"on_delete:CASCADE"`
 
 	Timestamps
 }

--- a/model/jwk.go
+++ b/model/jwk.go
@@ -5,7 +5,7 @@ type Jwk struct {
 	kid string `pg:",notnull"`
 	pem string `pg:",notnull"`
 
-	ApplicationID int64
+	ApplicationID int64 `pg:"on_delete:CASCADE"`
 
 	Timestamps
 }

--- a/model/jwk.go
+++ b/model/jwk.go
@@ -5,5 +5,7 @@ type Jwk struct {
 	kid string `pg:",notnull"`
 	pem string `pg:",notnull"`
 
+	ApplicationID int64
+
 	Timestamps
 }

--- a/model/lti_deployment.go
+++ b/model/lti_deployment.go
@@ -4,8 +4,8 @@ type LtiDeployment struct {
 	ID           int64
 	DeploymentID string `pg:",notnull"`
 
-	LtiInstallID          int64
-	ApplicationInstanceID int64
+	LtiInstallID          int64 `pg:"on_delete:CASCADE"`
+	ApplicationInstanceID int64 `pg:"on_delete:CASCADE"`
 
 	Timestamps
 }

--- a/model/lti_deployment.go
+++ b/model/lti_deployment.go
@@ -4,5 +4,8 @@ type LtiDeployment struct {
 	ID           int64
 	DeploymentID string `pg:",notnull"`
 
+	LtiInstallID          int64
+	ApplicationInstanceID int64
+
 	Timestamps
 }

--- a/model/lti_install.go
+++ b/model/lti_install.go
@@ -4,7 +4,7 @@ type LtiInstall struct {
 	ID             int64
 	LtiDeployments []*LtiDeployment `pg:"rel:has-many"`
 
-	ApplicationID int64
+	ApplicationID int64 `pg:"on_delete:CASCADE"`
 
 	Timestamps
 }

--- a/model/lti_install.go
+++ b/model/lti_install.go
@@ -4,5 +4,7 @@ type LtiInstall struct {
 	ID             int64
 	LtiDeployments []*LtiDeployment `pg:"rel:has-many"`
 
+	ApplicationID int64
+
 	Timestamps
 }

--- a/model/lti_launch.go
+++ b/model/lti_launch.go
@@ -1,0 +1,15 @@
+package model
+
+type LtiLaunch struct {
+	ID                       int64
+	DeploymentID             string             `pg:",notnull"`
+	Config                   *ApplicationConfig `pg:"type:jsonb,notnull"`
+	ContextID                string             `pg:",notnull"`
+	ResourceLinkID           string             `pg:",notnull"`
+	Token                    string             `pg:",notnull"`
+	ToolConsumerInstanceGuid string             `pg:",notnull"`
+
+	ApplicationInstanceID int64
+
+	Timestamps
+}

--- a/model/lti_launch.go
+++ b/model/lti_launch.go
@@ -9,7 +9,7 @@ type LtiLaunch struct {
 	Token                    string             `pg:",notnull"`
 	ToolConsumerInstanceGuid string             `pg:",notnull"`
 
-	ApplicationInstanceID int64
+	ApplicationInstanceID int64 `pg:"on_delete:CASCADE"`
 
 	Timestamps
 }

--- a/model/user.go
+++ b/model/user.go
@@ -8,7 +8,7 @@ type User struct {
 	LtiUserId   string `pg:",notnull"`
 	LtiProvider string `pg:",notnull"`
 
-	ApplicationInstanceID int64
+	ApplicationInstanceID int64 `pg:"on_delete:CASCADE"`
 
 	Timestamps
 }

--- a/model/user.go
+++ b/model/user.go
@@ -8,5 +8,7 @@ type User struct {
 	LtiUserId   string `pg:",notnull"`
 	LtiProvider string `pg:",notnull"`
 
+	ApplicationInstanceID int64
+
 	Timestamps
 }

--- a/repo/connection.go
+++ b/repo/connection.go
@@ -1,4 +1,4 @@
-package model
+package repo
 
 import (
 	"github.com/atomicjolt/atomic_insight/config"

--- a/repo/lti_launch_repo.go
+++ b/repo/lti_launch_repo.go
@@ -1,0 +1,21 @@
+package repo
+
+import "github.com/atomicjolt/atomic_insight/model"
+
+type LtiLaunchRepo struct {
+	*BaseRepo
+}
+
+func (r *LtiLaunchRepo) All() ([]model.LtiLaunch, error) {
+	var ltiLaunches []model.LtiLaunch
+	err := r.DB.Model(&ltiLaunches).Select()
+
+	return ltiLaunches, err
+}
+
+func (r *LtiLaunchRepo) Find(id int64) (*model.LtiLaunch, error) {
+	client := &model.LtiLaunch{ID: id}
+	err := r.DB.Model(client).WherePK().Select()
+
+	return client, err
+}


### PR DESCRIPTION
Instead of writing a new migration to fix this awkward process, I just refactored the original migration so that the LTI migration is complete and hopefully not more confusing (rather than having it partially correct in the first migration, then a second that amends it).

NOTE: You will have to `dropdb` your existing databases then `createdb` them again before running the migrations. A simple rollback won't work, since I also added the `LtiLaunch` model in this PR which would make rolling back error out since it would try to drop a table that didn't exist.