### PR TITLE
Fixed namespacing issue with GetConnection

### DIFF
--- a/server.go
+++ b/server.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/atomicjolt/atomic_insight/config"
 	"github.com/atomicjolt/atomic_insight/controllers"
-	"github.com/atomicjolt/atomic_insight/model"
 	"github.com/atomicjolt/atomic_insight/repo"
 	"github.com/gorilla/handlers"
 )
@@ -19,7 +18,7 @@ func main() {
 	port := localConfig.ServerPort
 	assetsPath := filepath.Join("client", localConfig.AssetsDir)
 
-	db := model.GetConnection()
+	db := repo.GetConnection()
 	insightRepo := repo.NewRepo(db)
 
 	router := controllers.NewRouter(insightRepo, assetsPath)


### PR DESCRIPTION
`GetConnection()` is from repo, not model