### PR TITLE
Kid and Pem must be uppercase

### DIFF
--- a/migrations/20210412211919_create_lti_schema.go
+++ b/migrations/20210412211919_create_lti_schema.go
@@ -69,8 +69,8 @@ type ApplicationInstance struct {
 
 type Jwk struct {
 	ID  int64
-	kid string `pg:",notnull"`
-	pem string `pg:",notnull"`
+	Kid string `pg:",notnull"`
+	Pem string `pg:",notnull"`
 
 	ApplicationID int64 `pg:"on_delete:CASCADE"`
 

--- a/model/jwk.go
+++ b/model/jwk.go
@@ -2,8 +2,8 @@ package model
 
 type Jwk struct {
 	ID  int64
-	kid string `pg:",notnull"`
-	pem string `pg:",notnull"`
+	Kid string `pg:",notnull"`
+	Pem string `pg:",notnull"`
 
 	ApplicationID int64 `pg:"on_delete:CASCADE"`
 


### PR DESCRIPTION
Lowercase fields are not exported, so gopg won't generate columns for
them. It might be desirable to make the pem private, to avoid leaking the private key.