### PR TITLE
Log panics and respond with 500

### DIFF
--- a/server.go
+++ b/server.go
@@ -22,7 +22,9 @@ func main() {
 	insightRepo := repo.NewRepo(db)
 
 	router := controllers.NewRouter(insightRepo, assetsPath)
-	middleware := handlers.RecoveryHandler()(handlers.LoggingHandler(os.Stdout, router))
+
+	middleware := handlers.LoggingHandler(os.Stdout, router)
+	middleware = handlers.RecoveryHandler()(middleware)
 
 	fmt.Printf("Listening on port %v\n", port)
 	log.Fatal(http.ListenAndServe(":"+port, middleware))

--- a/server.go
+++ b/server.go
@@ -22,8 +22,8 @@ func main() {
 	insightRepo := repo.NewRepo(db)
 
 	router := controllers.NewRouter(insightRepo, assetsPath)
-	handler := handlers.RecoveryHandler()(handlers.LoggingHandler(os.Stdout, router))
+	middleware := handlers.RecoveryHandler()(handlers.LoggingHandler(os.Stdout, router))
 
 	fmt.Printf("Listening on port %v\n", port)
-	log.Fatal(http.ListenAndServe(":"+port, handler))
+	log.Fatal(http.ListenAndServe(":"+port, middleware))
 }

--- a/server.go
+++ b/server.go
@@ -22,7 +22,8 @@ func main() {
 	insightRepo := repo.NewRepo(db)
 
 	router := controllers.NewRouter(insightRepo, assetsPath)
+	handler := handlers.RecoveryHandler()(handlers.LoggingHandler(os.Stdout, router))
 
 	fmt.Printf("Listening on port %v\n", port)
-	log.Fatal(http.ListenAndServe(":"+port, handlers.LoggingHandler(os.Stdout, router)))
+	log.Fatal(http.ListenAndServe(":"+port, handler))
 }


### PR DESCRIPTION
Gorilla mux provides a middleware that catches panics (exceptions), logs
them, and responds with a 500 code. We should use `log.Panic` instead of
`log.Fatal` in controllers.