### PR TITLE
JWT validation middleware

### DIFF
--- a/middleware/jwt_validation.go
+++ b/middleware/jwt_validation.go
@@ -1,0 +1,39 @@
+package middleware
+
+import (
+	"context"
+	"github.com/lestrrat-go/jwx/jwa"
+	"net/http"
+
+	"github.com/lestrrat-go/jwx/jwt"
+)
+
+//See docs for context.WithValue
+type contextKey int
+
+const DecodedJwtKey contextKey = 0
+
+func NewJwtValidator(jwtKey string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token, err := jwt.ParseRequest(r,
+			jwt.WithFormKey(jwtKey),
+			jwt.WithValidate(true),
+			jwt.WithVerify(jwa.HS256, []byte("shared_secret")),
+		)
+
+		if err != nil {
+			panic(err)
+		}
+
+		//Totally undocumented why a context is needed here
+		claims, err := token.AsMap(context.Background())
+
+		if err != nil {
+			panic(err)
+		}
+
+		newCtx := context.WithValue(r.Context(), DecodedJwtKey, claims)
+		newReq := r.WithContext(newCtx)
+		next.ServeHTTP(w, newReq)
+	})
+}


### PR DESCRIPTION
Currently looks for a POST param, and stores the token as a map in the context. Could be modified to keep the request body intact, by cloning it first. Also could save the jwt as a `jwt.Token` instead of using `AsMap()`