### PR TITLE
Debug middleware for development

### DIFF
--- a/middleware/debug.go
+++ b/middleware/debug.go
@@ -1,0 +1,21 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+)
+
+func NewDebugger(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		dump, err := httputil.DumpRequest(r, true)
+
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Printf("\n%s", dump)
+
+		next.ServeHTTP(w, r)
+	})
+}


### PR DESCRIPTION
Adds a convenience middleware that prints request contents, headers, etc. Should be useful for development.