### PR TITLE
Enable use of Create React App's hot reload server

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -20,43 +20,6 @@ cat > "/usr/local/etc/nginx/servers/atomic_insight.conf" <<-EOF
 server {
 
     listen *:443;
-    server_name atomicinsightassets.atomicjolt.xyz;
-
-    ssl on;
-    ssl_session_cache         builtin:1000  shared:SSL:10m;
-    ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers               HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
-    ssl_prefer_server_ciphers on;
-
-    ssl_certificate     ssl/STAR_atomicjolt_xyz.crt;
-    ssl_certificate_key ssl/STAR_atomicjolt_xyz.key;
-
-    location / {
-
-      proxy_set_header   Host \$host;
-      proxy_set_header   X-Forwarded-Ssl on;
-      proxy_set_header   X-Forwarded-For \$remote_addr;
-      proxy_set_header   X-Forwarded-Proto \$scheme;
-      proxy_set_header   X-Real-IP        \$remote_addr;
-      proxy_http_version 1.1;
-      proxy_pass         http://127.0.0.1:3000/;
-
-    }
-
-    # Proxy webpack dev server websocket requests
-    location /sockjs-node {
-      proxy_redirect off;
-      proxy_http_version 1.1;
-      proxy_set_header Upgrade \$http_upgrade;
-      proxy_set_header Connection "upgrade";
-      proxy_pass http://127.0.0.1:8080;
-    }
-}
-
-# Used to access production version
-server {
-
-    listen *:443;
     server_name atomicinsight.atomicjolt.xyz;
 
     ssl on;
@@ -79,6 +42,15 @@ server {
       # TODO make this port dynamic
       proxy_pass         http://127.0.0.1:8888/;
 
+    }
+
+    # Proxy webpack dev server websocket requests
+    location /sockjs-node {
+      proxy_redirect off;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade \$http_upgrade;
+      proxy_set_header Connection "Upgrade";
+      proxy_pass http://127.0.0.1:3000;
     }
 }
 EOF

--- a/bin/setup-linux
+++ b/bin/setup-linux
@@ -20,33 +20,6 @@ cat > "/etc/nginx/sites-available/atomicinsight.conf" <<-EOF
 server {
 
     listen *:443;
-    server_name atomicinsightassets.atomicjolt.xyz;
-
-    ssl on;
-    ssl_session_cache         builtin:1000  shared:SSL:10m;
-    ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers               HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
-    ssl_prefer_server_ciphers on;
-
-    ssl_certificate     ssl/STAR_atomicjolt_xyz.crt;
-    ssl_certificate_key ssl/STAR_atomicjolt_xyz.key;
-
-    location / {
-
-      proxy_set_header   Host \$host;
-      proxy_set_header   X-Forwarded-Ssl on;
-      proxy_set_header   X-Forwarded-For \$remote_addr;
-      proxy_set_header   X-Forwarded-Proto \$scheme;
-      proxy_set_header   X-Real-IP        \$remote_addr;
-      proxy_http_version 1.1;
-      proxy_pass         http://127.0.0.1:3000/;
-
-    }
-}
-
-server {
-
-    listen *:443;
     server_name atomicinsight.atomicjolt.xyz;
 
     ssl on;
@@ -68,6 +41,15 @@ server {
       proxy_http_version 1.1;
       proxy_pass         http://127.0.0.1:8888/;
 
+    }
+
+    # Proxy webpack dev server websocket requests
+    location /sockjs-node {
+      proxy_redirect off;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade \$http_upgrade;
+      proxy_set_header Connection "Upgrade";
+      proxy_pass http://127.0.0.1:3000;
     }
 }
 EOF

--- a/config/config.go
+++ b/config/config.go
@@ -5,7 +5,7 @@ import (
 	"os"
 )
 
-func determineEnv() string {
+func DetermineEnv() string {
 	if flag.Lookup("test.v") != nil {
 		return "test"
 	}

--- a/config/server.go
+++ b/config/server.go
@@ -30,7 +30,7 @@ func GetServerConfig() *ServerConfig {
 			log.Fatal("Server config file is not valid json: " + err.Error())
 		}
 
-		env := determineEnv()
+		env := DetermineEnv()
 		selectedConfig, isPresent := configs[env]
 		if !isPresent {
 			log.Fatal("Server config not found for env: " + env)

--- a/controllers/hot_reload.go
+++ b/controllers/hot_reload.go
@@ -1,0 +1,18 @@
+package controllers
+
+import (
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+)
+
+func NewHotReloadProxy(rawUrl string) http.Handler {
+	filesUrl, err := url.Parse(rawUrl)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return httputil.NewSingleHostReverseProxy(filesUrl)
+}

--- a/controllers/lti_launch.go
+++ b/controllers/lti_launch.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"github.com/atomicjolt/atomic_insight/config"
 	"github.com/atomicjolt/atomic_insight/webpack"
 
 	"net/http"

--- a/controllers/lti_launch.go
+++ b/controllers/lti_launch.go
@@ -19,14 +19,20 @@ func index(w http.ResponseWriter) error {
 		return err
 	}
 
-	manifest, err := webpack.NewFromBuildPath("client/build")
+	var manifest *webpack.Manifest
 
-	state := &ViewState{
-		Manifest: manifest,
+	if config.DetermineEnv() == "development" {
+		manifest, err = webpack.NewFromDevServer("http://127.0.0.1:3000/asset-manifest.json")
+	} else {
+		manifest, err = webpack.NewFromBuildPath("client/build")
 	}
 
 	if err != nil {
 		return err
+	}
+
+	state := &ViewState{
+		Manifest: manifest,
 	}
 
 	return view.Execute(w, state)

--- a/controllers/router.go
+++ b/controllers/router.go
@@ -23,7 +23,8 @@ func NewRouter() *mux.Router {
 	router.HandleFunc("/lti_launches", controllerContext.NewLtiLaunchHandler())
 	router.HandleFunc("/oidc_init", controllerContext.NewOpenIDInitHandler())
 	router.HandleFunc("/jwks", controllerContext.NewJwksController())
-	router.Handle("/{path:.*}", controllerContext.NewClientFilesHandler())
+
+	router.Handle("/{path:.*}", NewHotReloadProxy("http://127.0.0.1:3000"))
 
 	return router
 }

--- a/controllers/router.go
+++ b/controllers/router.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"github.com/99designs/gqlgen/graphql/playground"
+	"github.com/atomicjolt/atomic_insight/config"
 	"github.com/atomicjolt/atomic_insight/middleware"
 	"github.com/atomicjolt/atomic_insight/repo"
 	"github.com/gorilla/mux"
@@ -24,7 +25,11 @@ func NewRouter() *mux.Router {
 	router.HandleFunc("/oidc_init", controllerContext.NewOpenIDInitHandler())
 	router.HandleFunc("/jwks", controllerContext.NewJwksController())
 
-	router.Handle("/{path:.*}", NewHotReloadProxy("http://127.0.0.1:3000"))
+	if config.DetermineEnv() == "development" {
+		router.Handle("/{path:.*}", NewHotReloadProxy("http://127.0.0.1:3000"))
+	} else {
+		router.Handle("/{path:.*}", controllerContext.NewClientFilesHandler())
+	}
 
 	return router
 }

--- a/webpack/webpack.go
+++ b/webpack/webpack.go
@@ -32,6 +32,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"path"
 	"strings"
@@ -44,6 +45,29 @@ type Manifest struct {
 
 type Files map[string]string
 type Entrypoints []string
+
+func NewFromDevServer(manifestUrl string) (*Manifest, error) {
+	manifest := &Manifest{}
+
+	res, err := http.Get(manifestUrl)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer res.Body.Close()
+	content, err := ioutil.ReadAll(res.Body)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(content, manifest); err != nil {
+		return nil, err
+	}
+
+	return manifest, nil
+}
 
 func NewFromBuildPath(buildPath string) (*Manifest, error) {
 	manifest := &Manifest{}


### PR DESCRIPTION
* Removes the unused asset subdomain from Nginx config
* Adds a websocket proxy to the main Nginx server declaration
* Enables a reverse proxy for the client files to use Create React App's server

To use, just run `yarn start` in the client directory, and start the go server as normal.