### PR TITLE
Print environment mode for convenience

### DIFF
--- a/server.go
+++ b/server.go
@@ -20,6 +20,7 @@ func main() {
 	middleware := handlers.LoggingHandler(os.Stdout, router)
 	middleware = handlers.RecoveryHandler()(middleware)
 
+	fmt.Printf("Running in %s mode...\n", config.DetermineEnv())
 	fmt.Printf("Listening on port %v\n", port)
 	log.Fatal(http.ListenAndServe(":"+port, middleware))
 }


### PR DESCRIPTION
Now that development mode requires the webpack-dev-server to be running, it might be convenient to see what mode the server is in when it starts